### PR TITLE
@media RWD aweful fix

### DIFF
--- a/CSSTidy/class.csstidy_print.php
+++ b/CSSTidy/class.csstidy_print.php
@@ -204,6 +204,7 @@ class csstidy_print
             }
         }
 
+		$output = preg_replace('#@media ([a-zA-Z\-]*) ([a-zA-Z0-9]*){#', '@media($1:$2){', $output);
         $output = trim($output);
 
         if (!$plain) {


### PR DESCRIPTION
A string like : @media (min-width: 800px) { ... } was compressed this way :
@media min-width 800px { ... } 
It doesn't work.

This fix (yes, hardcoded and not really optimized) works.
Now, a @media (min-width: 800px) { ... } is compressed like this :
@media(min-width:800px) { ... } 

I did it for my own needs, but you can surely improve that to handle multiple media conditions (@media screen and (min-width: 200px) and (max-width: 640px) { ... } for example, which is NOT fixed at all for now).
